### PR TITLE
fix: use lib file in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,11 +37,11 @@
     "build": "tsc -p tsconfig.build.json",
     "lint": "eslint src && prettier -c ."
   },
-  "main": "dist/index.js",
+  "main": "dist/lib.js",
   "files": [
     "dist/**/*"
   ],
-  "types": "dist/index.d.ts",
+  "types": "dist/lib.d.ts",
   "jest": {
     "testEnvironment": "node",
     "collectCoverage": true,


### PR DESCRIPTION
This fixes an issue where importing the modukle would not be possible due to incorrect declarations in package.json